### PR TITLE
Net::LDAP compatibility

### DIFF
--- a/lib/omniauth-ldap/adaptor.rb
+++ b/lib/omniauth-ldap/adaptor.rb
@@ -49,7 +49,6 @@ module OmniAuth
         config = {
           :host => @host,
           :port => @port,
-          :encryption => method,
           :base => @base
         }
         @bind_method = @try_sasl ? :sasl : (@allow_anonymous||!@bind_dn||!@password ? :anonymous : :simple)
@@ -62,6 +61,7 @@ module OmniAuth
                   }
         config[:auth] = @auth
         @connection = Net::LDAP.new(config)
+        @connection.encryption(method)
       end
 
       #:base => "dc=yourcompany, dc=com",

--- a/spec/omniauth-ldap/adaptor_spec.rb
+++ b/spec/omniauth-ldap/adaptor_spec.rb
@@ -52,6 +52,11 @@ describe "OmniAuth::LDAP::Adaptor" do
       adaptor.connection.instance_variable_get('@auth')[:initial_credential].should =~ /^NTLMSSP/
       adaptor.connection.instance_variable_get('@auth')[:challenge_response].should_not be_nil
     end
+
+    it 'should set the encryption method correctly' do
+      adaptor = OmniAuth::LDAP::Adaptor.new({host: "192.168.1.145", method: 'tls', base: 'dc=intridea, dc=com', port: 389, uid: 'sAMAccountName'})
+      adaptor.connection.instance_variable_get('@encryption').should include method: :start_tls
+    end
   end
 
   describe 'bind_as' do


### PR DESCRIPTION
Passing the encryption method to `Net::LDAP#new` is apparently not officially supported prior to version 0.13.0 of the `net-ldap` gem. And even then, the API is a bit different from how it is used here. When passed as a parameter to he initializer, Net::LDAP expects it to be a hash or an array.

The "right" way to do it prior to 0.13.0 (which, given the versions as stated in the `gemspec`, is the way this library would have to take) is to call `Net::LDAP#encryption` after its creation. This then even works with just giving it a symbol; it will do normalization for you. It will also warn you about its deprecation with versions of `net-ldap` from 0.13.0 onwards.

All this is supported by ruby-ldap/ruby-net-ldap#250.

Note that this wouldn't show up in the tests as this causes an error only in `Net::LDAP#open`, not in the initializer itself, but any call to this method is stubbed out in the test suite.